### PR TITLE
Add basic pytest config and workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,20 @@
+name: Pytest
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install .
+          pip install pytest pytest-asyncio
+      - name: Run tests
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ repository = "https://github.com/nodetool-ai/nodetool-lib-network"
 [tool.poetry.dependencies]
 python = "^3.10"
 nodetool-core = { git = "https://github.com/nodetool-ai/nodetool-core.git", rev = "main" }
+
+[tool.pytest.ini_options]
+addopts = "-ra"

--- a/tests/test_titles.py
+++ b/tests/test_titles.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+import types
+import nodetool.nodes.lib.network.http as http
+
+
+def test_get_request_title():
+    assert http.GetRequest.get_title() == "GET Request"
+
+
+def test_fetch_rss_feed_title(monkeypatch):
+    dummy = types.SimpleNamespace(parse=lambda url: types.SimpleNamespace(feed={}, entries=[]))
+    monkeypatch.setitem(sys.modules, "feedparser", dummy)
+    rss = importlib.import_module("nodetool.nodes.lib.network.rss")
+    importlib.reload(rss)
+    assert rss.FetchRSSFeed.get_title() == "Fetch RSS Feed"


### PR DESCRIPTION
## Summary
- add a simple workflow to run pytest
- configure pytest via `pyproject.toml`
- add basic tests that check titles of HTTP and RSS nodes

## Testing
- `pytest tests/test_titles.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nodetool.nodes.lib.network.imap', ModuleNotFoundError: No module named 'feedparser')*